### PR TITLE
Casenoteswithattachments

### DIFF
--- a/Models/Verint/Case.cs
+++ b/Models/Verint/Case.cs
@@ -18,6 +18,7 @@ namespace StockportGovUK.NetStandard.Models.Verint
             this.CustomAttributes = new List<CustomField>();
             this.CaseReference = string.Empty;
             this.RaisedByBehaviour = RaisedByBehaviourEnum.Individual;
+            this.NotesWithAttachments = new List<NoteWithAttachments>();
 
         }
 
@@ -38,6 +39,10 @@ namespace StockportGovUK.NetStandard.Models.Verint
         public List<CustomField> CaseFormFields { get; set; }
 
         public List<Note> Notes { get; set; } 
+
+        public List<NoteWithAttachments> NotesWithAttachments { get; set; } 
+
+        public bool UploadNotesWithAttachmentsAfterCaseCreation { get; set; }
 
         public string FormName { get; set; }
 

--- a/Models/Verint/Note/NoteWithAttachments.cs
+++ b/Models/Verint/Note/NoteWithAttachments.cs
@@ -6,13 +6,16 @@ namespace StockportGovUK.NetStandard.Models.Verint
 {
     public class NoteWithAttachments
     {
-        [Required]
-        [RegularExpression("^[0-9]{12}$", ErrorMessage = "CaseRef must be a valid reference number")]
-        public long CaseRef { get; set; }
+        [RegularExpression("^$|^[0-9]{12}$", ErrorMessage = "CaseRef must be a valid reference number")]
+        public long CaseRef { get; set; } 
+        
         [Required]
         public List<File> Attachments { get; set; }
+
         public string AttachmentsDescription { get; set; } = string.Empty;
+
         public int Interaction { get; set; } = 0;
+
         public string NoteName { get; set; }
     }
 }


### PR DESCRIPTION
Enables case notes with attachment as part of case object for use on submission of case as well as after the fact.