### PR TITLE
Reinstated PropertyCentralAssetId into PropertyWasteData

### DIFF
--- a/Models/WasteDataService/Response/PropertyWasteData.cs
+++ b/Models/WasteDataService/Response/PropertyWasteData.cs
@@ -27,5 +27,7 @@ namespace StockportGovUK.NetStandard.Models.WasteDataService.Response
                     || AssistedCollection.Stop >= DateTime.Now);
             }
         }
+
+        public string PropertyCentralAssetId { get; set; }
     }
 }

--- a/StockportGovUK.NetStandard.Models.csproj
+++ b/StockportGovUK.NetStandard.Models.csproj
@@ -3,7 +3,7 @@
     <PackageId>StockportGovUK.NetStandard.Models</PackageId>
     <Title>A package that provides shared models for StockportGovUK applications</Title>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <VersionPrefix>3.18.0</VersionPrefix>
+    <VersionPrefix>3.18.1</VersionPrefix>
     <Authors>Colin Lees, Jon Chiles, Jon Hadley</Authors>
     <Company>Stockport Council</Company>
   </PropertyGroup>


### PR DESCRIPTION
inadvertantly deleted PropertyCentralAssetId from PropertyWasteData. Now restores